### PR TITLE
allow CIGAR encoding with code 7 and 8

### DIFF
--- a/shorah/b2w.py
+++ b/shorah/b2w.py
@@ -41,14 +41,12 @@ def _calc_location_maximum_reads(samfile, reference_name, maximum_reads):
     return budget, indel_map
 
 def _run_one_window(samfile, window_start, reference_name, window_length,
-        win_min_ext, permitted_reads_per_location, counter,
+        minimum_overlap, permitted_reads_per_location, counter,
         exact_conformance_fix_0_1_basing_in_reads, indel_map):
 
     arr = []
     arr_read_summary = []
     arr_read_qualities_summary = []
-    
-    minimum_overlap = math.floor(win_min_ext * window_length)
 
     iter = samfile.fetch(
         reference_name,
@@ -179,7 +177,7 @@ def build_windows(alignment_file: str, tiling_strategy: TilingStrategy,
     Args:
         alignment_file: Path to the alignment file in CRAM format.
         tiling_strategy: A strategy on how the genome is partitioned.
-        minimum_overlap: Minimum number of bases to overlap between reference
+        win_min_ext: Minimum percentage of bases to overlap between reference
             and read to be considered in a window. The rest (i.e.
             non-overlapping part) will be filled with Ns.
         maximum_reads: Upper (exclusive) limit of reads allowed to start at the
@@ -216,13 +214,15 @@ def build_windows(alignment_file: str, tiling_strategy: TilingStrategy,
         maximum_reads
     )
 
+    minimum_overlap = math.floor(win_min_ext * window_length)
+
     for idx, (window_start, window_length) in enumerate(tiling):
         arr, arr_read_qualities_summary, arr_read_summary, counter = _run_one_window(
             samfile,
             window_start - 1, # make 0 based
             reference_name,
             window_length,
-            win_min_ext,
+            minimum_overlap,
             dict(permitted_reads_per_location), # copys dict ("pass by value")
             counter,
             exact_conformance_fix_0_1_basing_in_reads,

--- a/shorah/b2w.py
+++ b/shorah/b2w.py
@@ -214,15 +214,13 @@ def build_windows(alignment_file: str, tiling_strategy: TilingStrategy,
         maximum_reads
     )
 
-    minimum_overlap = math.floor(win_min_ext * window_length)
-
     for idx, (window_start, window_length) in enumerate(tiling):
         arr, arr_read_qualities_summary, arr_read_summary, counter = _run_one_window(
             samfile,
             window_start - 1, # make 0 based
             reference_name,
             window_length,
-            minimum_overlap,
+            math.floor(win_min_ext * window_length),
             dict(permitted_reads_per_location), # copys dict ("pass by value")
             counter,
             exact_conformance_fix_0_1_basing_in_reads,
@@ -281,7 +279,7 @@ if __name__ == "__main__":
         help='window length', required=True)
     parser.add_argument('-i', '--incr', nargs=1, type=int, help='increment',
         required=True)
-    parser.add_argument('-m', nargs=1, type=float, help='minimum overlap',
+    parser.add_argument('-m', nargs=1, type=float, help='minimum overlap in percent',
         required=True)
     parser.add_argument('-x', nargs=1, type=int,
         help='max reads starting at a position', required=True)

--- a/shorah/b2w.py
+++ b/shorah/b2w.py
@@ -75,7 +75,7 @@ def _run_one_window(samfile, window_start, reference_name, window_length,
         full_qualities = list(read.query_qualities)
 
         for ct_idx, ct in enumerate(read.cigartuples):
-            if ct[0] in [0,1,2]: # 0 = BAM_, 1 = BAM_CINS, 2 = BAM_CDEL
+            if ct[0] in [0,1,2,7,8]: # 0 = BAM_, 1 = BAM_CINS, 2 = BAM_CDEL, 7 = BAM_CEQUAL, 8 = BAM_CDIFF
                 pass
             elif ct[0] == 4: # 4 = BAM_CSOFT_CLIP
                 for _ in range(ct[1]):

--- a/shorah/b2w.py
+++ b/shorah/b2w.py
@@ -191,6 +191,7 @@ def build_windows(alignment_file: str, tiling_strategy: TilingStrategy,
             applied everywhere now. Set this flag to `False` only for exact
             conformance with the old version (in tests).
     """
+    assert 0 <= win_min_ext <= 1
 
     pysam.index(alignment_file)
     samfile = pysam.AlignmentFile(

--- a/shorah/b2w.py
+++ b/shorah/b2w.py
@@ -2,6 +2,7 @@ import pysam
 from typing import Optional
 from shorah.tiling import TilingStrategy, EquispacedTilingStrategy
 import numpy as np
+import math
 
 def _write_to_file(lines, file_name):
     with open(file_name, "w") as f:
@@ -40,12 +41,14 @@ def _calc_location_maximum_reads(samfile, reference_name, maximum_reads):
     return budget, indel_map
 
 def _run_one_window(samfile, window_start, reference_name, window_length,
-        minimum_overlap, permitted_reads_per_location, counter,
+        win_min_ext, permitted_reads_per_location, counter,
         exact_conformance_fix_0_1_basing_in_reads, indel_map):
 
     arr = []
     arr_read_summary = []
     arr_read_qualities_summary = []
+    
+    minimum_overlap = math.floor(win_min_ext * window_length)
 
     iter = samfile.fetch(
         reference_name,
@@ -163,7 +166,7 @@ def _run_one_window(samfile, window_start, reference_name, window_length,
 
 
 def build_windows(alignment_file: str, tiling_strategy: TilingStrategy,
-    minimum_overlap: int, maximum_reads: int, minimum_reads: int,
+    win_min_ext: float, maximum_reads: int, minimum_reads: int,
     reference_filename: str,
     exact_conformance_fix_0_1_basing_in_reads: Optional[bool] = False) -> None:
     """Summarizes reads aligned to reference into windows.
@@ -219,7 +222,7 @@ def build_windows(alignment_file: str, tiling_strategy: TilingStrategy,
             window_start - 1, # make 0 based
             reference_name,
             window_length,
-            minimum_overlap,
+            win_min_ext,
             dict(permitted_reads_per_location), # copys dict ("pass by value")
             counter,
             exact_conformance_fix_0_1_basing_in_reads,
@@ -278,7 +281,7 @@ if __name__ == "__main__":
         help='window length', required=True)
     parser.add_argument('-i', '--incr', nargs=1, type=int, help='increment',
         required=True)
-    parser.add_argument('-m', nargs=1, type=int, help='minimum overlap',
+    parser.add_argument('-m', nargs=1, type=float, help='minimum overlap',
         required=True)
     parser.add_argument('-x', nargs=1, type=int,
         help='max reads starting at a position', required=True)

--- a/shorah/shotgun.py
+++ b/shorah/shotgun.py
@@ -427,7 +427,6 @@ def main(args):
     """
     from multiprocessing import Pool, cpu_count
     import glob
-    import math
     import time
     import pysam
 
@@ -506,7 +505,7 @@ def main(args):
         b2w.build_windows(
             in_bam,
             strategy,
-            math.floor(win_min_ext * win_length),
+            win_min_ext,
             max_coverage,
             cov_thrd,
             in_fasta

--- a/tests/data_6/README.md
+++ b/tests/data_6/README.md
@@ -2,24 +2,26 @@
 
 Use files in this directory to test shorah in shotgun mode. The reads data have been generated with V-pipe's benchmarking framework (simulated with parameters (seq_tech~illumina__seq_mode~shotgun__seq_mode_param~nan__read_length~90__genome_size~90__coverage~100__haplos~5@5@10@5@10@geom@0.75)
 
-The reads stam from one single amplicon of length 90, meaning the reference is of length 90 and each read is of length 90bps.
+The reads are from one single amplicon of length 90, meaning the reference is of length 90 and each read is of length 90bps.
 
 To run ShoRAH's original Gibbs sampler use the following command:
 ```
-poetry run shorah shotgun -f reference.fasta -b reads.shotgun.bam -w 90 --shorah
+poetry run shorah shotgun -f reference.fasta -b reads.shotgun.bam -w 90 --sampler shorah
 ```
-
-If only one window should cover the amplicon set in addtion the parameter `-s 1`.
+or
+```
+poetry run shorah shotgun -f reference.fasta -b reads.shotgun.bam -z scheme.insert.bed --sampler shorah
+```
 
 To use the new inference method using the sequencing quality scores use:
 ```
-poetry run shorah shotgun -f reference.fasta -b reads.shotgun.bam -w 90 --use_quality_scores --alpha 0.0001 --n_max_haplotypes 100 --n_mfa_starts 1 --conv_thres 0.0001
+poetry run shorah shotgun -f reference.fasta -b reads.shotgun.bam -w 90 --sampler use_quality_scores --alpha 0.0001 --n_max_haplotypes 100 --n_mfa_starts 1 --conv_thres 0.0001
 ```
 To use the new inference method learning the sequencing error parameter:
 ```
-poetry run shorah shotgun -f reference.fasta -b reads.shotgun.bam -w 90 --learn_error_params --alpha 0.0001 --n_max_haplotypes 100 --n_mfa_starts 1 --conv_thres 0.0001
+poetry run shorah shotgun -f reference.fasta -b reads.shotgun.bam -w 90 --sampler -learn_error_params --alpha 0.0001 --n_max_haplotypes 100 --n_mfa_starts 1 --conv_thres 0.0001
 ```
 
 In the new inference method reads are filtered (and weighted respectively) such that only a set of unique reads are processed. This mode can be switch off by setting the parameter `--non-unique_modus`,  e.g.:
 ```
-poetry run shorah shotgun -f reference.fasta -b reads.shotgun.bam -w 90 --learn_error_params --alpha 0.0001 --n_max_haplotypes 100 --n_mfa_starts 1 --conv_thres 0.0001 --non-unique_modus
+poetry run shorah shotgun -f reference.fasta -b reads.shotgun.bam -w 90 --sampler -learn_error_params --alpha 0.0001 --n_max_haplotypes 100 --n_mfa_starts 1 --conv_thres 0.0001 --non-unique_modus

--- a/tests/data_6/README.md
+++ b/tests/data_6/README.md
@@ -1,6 +1,6 @@
 ### Sample files to test `shorah shotgun`
 
-Use files in this directory to test shorah in shotgun mode. The reads data have been generated with V-pipe's benchmarking framework (simulated with parameters (seq_tech~illumina__seq_mode~shotgun__seq_mode_param~nan__read_length~90__genome_size~90__coverage~100__haplos~5@5@10@5@10@geom@0.75)
+Use files in this directory to test shorah in shotgun mode. The reads data have been generated with V-pipe's benchmarking framework (simulated with parameters: ```seq_tech~illumina__seq_mode~shotgun__seq_mode_param~nan__read_length~90__genome_size~90__coverage~100__haplos~5@5@10@5@10@geom@0.75```)
 
 The reads are from one single amplicon of length 90, meaning the reference is of length 90 and each read is of length 90bps.
 

--- a/tests/data_6/scheme.insert.bed
+++ b/tests/data_6/scheme.insert.bed
@@ -1,0 +1,1 @@
+MasterSequence	1	91	scheme_INSERT_1	1	+

--- a/tests/test_b2w.py
+++ b/tests/test_b2w.py
@@ -44,6 +44,7 @@ def _collect_files(base_path):
 def test_cmp_raw(spec_dir, alignment_file, reference_file, region, window_length,overlap_factor, win_min_ext, maximum_reads, minimum_reads):
     assert window_length > 0 and window_length%overlap_factor == 0
     incr = window_length//overlap_factor
+    minimum_overlap = math.floor(win_min_ext * window_length)
 
     os.chdir(os.path.join(p, spec_dir))
     returncode = libshorah.b2w(
@@ -51,7 +52,7 @@ def test_cmp_raw(spec_dir, alignment_file, reference_file, region, window_length
         reference_file,
         window_length,
         incr,
-        win_min_ext,
+        minimum_overlap,
         maximum_reads,
         minimum_reads,
         False,
@@ -65,7 +66,7 @@ def test_cmp_raw(spec_dir, alignment_file, reference_file, region, window_length
     b2w.build_windows(
         alignment_file = os.path.join(p, spec_dir, alignment_file),
         tiling_strategy = strategy,
-        minimum_overlap = minimum_overlap,
+        win_min_ext = win_min_ext,
         maximum_reads = maximum_reads,
         minimum_reads = minimum_reads,
         reference_filename = os.path.join(p, spec_dir, reference_file),

--- a/tests/test_b2w.py
+++ b/tests/test_b2w.py
@@ -43,7 +43,6 @@ def _collect_files(base_path):
 ], indirect=["spec_dir"])
 def test_cmp_raw(spec_dir, alignment_file, reference_file, region, window_length,overlap_factor, win_min_ext, maximum_reads, minimum_reads):
     assert window_length > 0 and window_length%overlap_factor == 0
-    minimum_overlap = math.floor(window_length * win_min_ext)
     incr = window_length//overlap_factor
 
     os.chdir(os.path.join(p, spec_dir))
@@ -52,7 +51,7 @@ def test_cmp_raw(spec_dir, alignment_file, reference_file, region, window_length
         reference_file,
         window_length,
         incr,
-        minimum_overlap,
+        win_min_ext,
         maximum_reads,
         minimum_reads,
         False,


### PR DESCRIPTION
Some data could have different CIGAR encoding (for example `tests/data_6`). 
Matching or mismatching letters could also be encoded with 7 or 8 as in `tests/data_6`.

For explanations of CIGAR encoding see: https://www.drive5.com/usearch/manual/cigar.html. 
