### PR TITLE
remove warning for hard clipping to improve runtime

### DIFF
--- a/shorah/b2w.py
+++ b/shorah/b2w.py
@@ -180,6 +180,7 @@ def _run_one_window(samfile, window_start, reference_name, window_length,
                     raise ValueError("Soft clipping only possible on the edges of a read.")
             elif ct[0] == 5: # 5 = BAM_CHARD_CLIP
                 #logging.debug(f"[b2w] Hard clipping detected in {read.query_name}")
+                pass
             else:
                 raise NotImplementedError("CIGAR op code found that is not implemented:", ct[0])
 

--- a/shorah/b2w.py
+++ b/shorah/b2w.py
@@ -179,7 +179,7 @@ def _run_one_window(samfile, window_start, reference_name, window_length,
                 if ct_idx != 0 and ct_idx != len(read.cigartuples)-1:
                     raise ValueError("Soft clipping only possible on the edges of a read.")
             elif ct[0] == 5: # 5 = BAM_CHARD_CLIP
-                logging.debug(f"[b2w] Hard clipping detected in {read.query_name}")
+                #logging.debug(f"[b2w] Hard clipping detected in {read.query_name}")
             else:
                 raise NotImplementedError("CIGAR op code found that is not implemented:", ct[0])
 
@@ -392,7 +392,7 @@ def build_windows(alignment_file: str, tiling_strategy: TilingStrategy,
                 _write_to_file([
                     f'>{reference_name} {window_start}\n' + ref
                 ], file_name + '.ref.fas')
-                
+
                 assert control_window_length == len(ref), (
                     f"""
                         Reference does not have same length as the window.


### PR DESCRIPTION
Remove warning in b2w of hard clipping detected. 

The motivation is to improve runtime in the preprocessing, in particular, for the Illumina HIV-5-Virus-Mix. 