### PR TITLE
add win_min_ext to commandline argument

### DIFF
--- a/shorah/cli.py
+++ b/shorah/cli.py
@@ -164,6 +164,9 @@ def main():
     parser_shotgun.add_argument("-w", "--windowsize", metavar='INT',
                                 required=False, type=int, dest="w", default=201, help="window size")
 
+    parser_shotgun.add_argument("--win_min_ext", metavar='FLOAT',
+                                required=False, type=float, dest="win_min_ext", default=0.85, help="win_min_ext: Minimum percentage of bases to overlap between reference and read to be considered in a window. The rest (i.e. non-overlapping part) will be filled with Ns.")
+
     parser_shotgun.add_argument("-s", "--winshifts", metavar='INT', required=False,
                                 type=int, default=3, dest="win_shifts", help="number of window shifts")
 

--- a/shorah/shotgun.py
+++ b/shorah/shotgun.py
@@ -69,7 +69,7 @@ from .local_haplotype_inference.learn_error_params import run_dpm_mfa as learn_e
 #################################################
 # parameters not controlled by command line options
 fasta_length = 80   # controls line length in fasta files
-win_min_ext = 0.85  # if read covers at least win_min_ext fraction of
+#win_min_ext = 0.85  # if read covers at least win_min_ext fraction of
 # the window, fill it with Ns
 hist_fraction = 0.20  # fraction that goes into the history
 min_quality = 0.9  # quality under which discard the correction
@@ -450,6 +450,7 @@ def main(args):
     unique_modus = args.unique_modus
     inference_convergence_threshold = args.conv_thres
     extended_window_mode = args.extended_window_mode
+    win_min_ext = args.win_min_ext
 
     logging.info(' '.join(sys.argv))
 


### PR DESCRIPTION
add win_min_ext as commandline argument 


win_min_ext: Minimum percentage of bases to overlap between reference and read to be considered in a window. The rest (i.e. non-overlapping part) will be filled with Ns.